### PR TITLE
Don't specify git branch

### DIFF
--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -31,5 +31,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/SrainApp/srain.git
-        branch: master
         commit: 01b3761d172ff57a881cbe759b523b33c7bd8fb0


### PR DESCRIPTION
Specifying both branch and commit only works if the commit is the latest one in the branch.