### PR TITLE
Update runtime to 3.36

### DIFF
--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: im.srain.Srain
 runtime: org.gnome.Platform
-runtime-version: '3.34'
+runtime-version: '3.36'
 sdk: org.gnome.Sdk
 command: srain
 finish-args:


### PR DESCRIPTION
Hi. Let's update GNOME runtime to 3.36? Tested, LGTM.