### PR TITLE
Drop home:ro filesystem permission

### DIFF
--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -6,7 +6,6 @@ sdk: org.gnome.Sdk
 command: srain
 finish-args:
   - "--share=ipc"
-  - "--filesystem=home:ro"
   - "--socket=pulseaudio"
   - "--socket=x11"
   - "--socket=wayland"


### PR DESCRIPTION
It's no longer necessary, configuration files use $XDG_CONFIG_HOME and srain doesn't allow sending arbitrary files.