### PR TITLE
Use fallback-x11

### DIFF
--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -10,6 +10,7 @@ finish-args:
   - "--socket=pulseaudio"
   - "--socket=x11"
   - "--socket=wayland"
+  - "--socket=fallback-x11"
   - "--share=network"
   - "--talk-name=org.freedesktop.secrets"
 modules:


### PR DESCRIPTION
fallback-x11 allows access to the x11 socket, but only when wayland is not present. This way users running wayland won't have the x11 socket unnecessarily open.

In order to ensure backwards compatibility with very old (older than 0.11.3) clients x11 is still present. Older clients will ignore fallback-x11 and work as before this change, but newer clients will override x11 giving the expected behaviour.