### PR TITLE
update runtime to gnome 45

### DIFF
--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: im.srain.Srain
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: '45'
 sdk: org.gnome.Sdk
 command: srain
 finish-args:


### PR DESCRIPTION
> Info: runtime **org.gnome.Platform** branch **43** is end-of-life, with reason:
  The GNOME 43 runtime is no longer supported as of September 20, 2023. Please ask your application developer to migrate to a supported platform.