### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,53 @@
+From 66cd9e1c87afd60fbfde8ce069f1cb1fba884cfe Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Fri, 15 Nov 2024 21:34:23 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ data/metainfo/srain.metainfo.xml.in.in | 25 +++----------------------
+ 1 file changed, 3 insertions(+), 22 deletions(-)
+
+diff --git a/data/metainfo/srain.metainfo.xml.in.in b/data/metainfo/srain.metainfo.xml.in.in
+index 95cbaa3..de5ace4 100644
+--- a/data/metainfo/srain.metainfo.xml.in.in
++++ b/data/metainfo/srain.metainfo.xml.in.in
+@@ -42,33 +42,14 @@
+   </screenshots>
+ 
+   <url type="homepage">@app_url@</url>
++  <url type="bugtracker">https://github.com/SrainApp/srain/issues</url>
++  <url type="vcs-browser">https://github.com/SrainApp/srain</url>
+ 
+   <provides>
+     <binary>@app_exec@</binary>
+   </provides>
+ 
+-  <content_rating type="oars-1.0">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">intense</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1"/>
+ 
+ <releases>
+   <release version="1.6.0" date="2024-02-11">
+--
+libgit2 1.7.2
+

--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: im.srain.Srain
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: srain
 finish-args:

--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -8,7 +8,6 @@ finish-args:
   - "--share=ipc"
   - "--filesystem=home:ro"
   - "--socket=pulseaudio"
-  - "--socket=x11"
   - "--socket=wayland"
   - "--socket=fallback-x11"
   - "--share=network"

--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -76,3 +76,5 @@ modules:
       - type: git
         url: https://github.com/SrainApp/srain.git
         commit: 7d842e21366241c21957d8369826be4e8df677ea
+      - type: patch
+        path: "fix-appdata.patch"


### PR DESCRIPTION
### Update GNOME runtime to version 47
- GNOME runtime version 45 has reached EOL.

### Fix appdata papercuts