### PR TITLE
Drop libsoup3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Srain
 
-___Modern IRC___
+___Modern IRC client___
 
 Modern IRC client written in GTK
 
@@ -24,4 +24,4 @@ flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --instal
 
 ---
 
-**Technologies**: GNOME, GTK4, C
+**Technologies**: GNOME, GTK3, C

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
-# im.srain.Srain
+# Srain
 
-Flatpak manifest
+___Modern IRC___
+
+Modern IRC client written in GTK
+
+---
+
+## Manual Install and Run
+
+Make sure you follow the [setup guide for your Linux distribution](https://flathub.org/en/setup) before installing.
+
+```bash
+flatpak install flathub im.srain.Srain
+flatpak run im.srain.Srain
+```
+
+## Building
+
+```bash
+git clone git@github.com:flathub/im.srain.Srain.git
+flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install im.srain.Srain.yaml
+```
+
+---
+
+**Technologies**: GNOME, GTK4, C

--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -1,5 +1,4 @@
----
-app-id: im.srain.Srain
+id: im.srain.Srain
 runtime: org.gnome.Platform
 runtime-version: '49'
 sdk: org.gnome.Sdk
@@ -23,19 +22,6 @@ cleanup:
   - "/share/vala"
 
 modules:
-  - name: libsoup
-    buildsystem: meson
-    builddir: true
-    config-opts:
-      - "--buildtype=release"
-      - "-Dvapi=enabled"
-      - "-Dtests=false"
-      - "-Dgssapi=disabled"
-      - "-Dsysprof=disabled"
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsoup/3.6/libsoup-3.6.5.tar.xz
-        sha256: 6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234
 
   - name: libconfig
     buildsystem: autotools
@@ -54,12 +40,14 @@ modules:
       - type: git
         url: https://github.com/AyatanaIndicators/ayatana-ido.git
         tag: 0.10.4
+
   - name: libayatana-indicator
     buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://github.com/AyatanaIndicators/libayatana-indicator.git
         tag: 0.9.4
+
   - name: libdbusmenu-gtk3
     buildsystem: autotools
     build-options:
@@ -76,6 +64,7 @@ modules:
       - type: archive
         url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
         sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
   - name: libayatana-appindicator
     buildsystem: cmake-ninja
     config-opts:

--- a/im.srain.Srain.yaml
+++ b/im.srain.Srain.yaml
@@ -40,6 +40,7 @@ modules:
       - type: git
         url: https://github.com/AyatanaIndicators/ayatana-ido.git
         tag: 0.10.4
+        commit: f968079b09e2310fefc3fc307359025f1c74b3eb
 
   - name: libayatana-indicator
     buildsystem: cmake-ninja
@@ -47,6 +48,7 @@ modules:
       - type: git
         url: https://github.com/AyatanaIndicators/libayatana-indicator.git
         tag: 0.9.4
+        commit: 611bb384b73fa6311777ba4c41381a06f5b99dad
 
   - name: libdbusmenu-gtk3
     buildsystem: autotools
@@ -74,6 +76,7 @@ modules:
       - type: git
         url: https://github.com/AyatanaIndicators/libayatana-appindicator.git
         tag: 0.5.92
+        commit: d214fe3e7a6b1ba8faea68d70586310b34dc643c
 
   - name: srain
     buildsystem: meson
@@ -84,3 +87,4 @@ modules:
       - type: git
         url: https://github.com/SrainApp/srain.git
         tag: 1.8.1
+        commit: 693c81b11052b6e287b5a734352dd813ef2b71aa


### PR DESCRIPTION
It is already provided by the runtime.

Fixes: https://github.com/flathub/im.srain.Srain/issues/42

Also, update README.md file to add some basic information.